### PR TITLE
Add Pyinstaller Support

### DIFF
--- a/pymusiclooper.spec
+++ b/pymusiclooper.spec
@@ -1,0 +1,46 @@
+# -*- mode: python ; coding: utf-8 -*-
+from PyInstaller.utils.hooks import collect_all
+
+datas = []
+binaries = []
+hiddenimports = []
+tmp_ret = collect_all('sounddevice')
+datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
+
+
+a = Analysis(
+    ['.\\pymusiclooper\\__main__.py'],
+    pathex=[],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='pymusiclooper',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    contents_directory='_pymusiclooper_internal',
+)


### PR DESCRIPTION
- Not dependent on poetry or plugins like #40 
- The implemented `__version__` approach to read from `importlib.metadata.version` is not compatible since no metadata is present. This might be addressed in a future commit, but this needs to be manually set for now.

To use, install the project and it's requirements in a venv, along with `pyinstaller==6.9.0` and then:

```sh
pyinstaller pymusiclooper.spec
```
