### PR TITLE
Support exporting and reading `LOOPLENGTH` tag

### DIFF
--- a/pymusiclooper/cli.py
+++ b/pymusiclooper/cli.py
@@ -217,8 +217,7 @@ def export_points(**kwargs):
 @common_loop_options
 @common_export_options
 @click.option('--tag-names', type=str, required=True, nargs=2, help='Name of the loop metadata tags to use, e.g. --tag-names LOOP_START LOOP_END')
-@click.option("--offset", is_flag=True, default=False, help="Always export latter loop metadata tag as a relative length (default auto-detects by name).")
-@click.option("--no-offset", is_flag=True, default=False, help="Always export latter loop metadata tag as an absolute end position (default auto-detects by name).")
+@click.option("--tag-offset/--no-tag-offset", is_flag=True, default=None, help="Always export second loop metadata tag as a relative length / or as an absolute length. Default: auto-detected based on tag name.")
 def tag(**kwargs):
     """Adds metadata tags of loop points to a copy of the input audio file(s)."""
     run_handler(**kwargs)

--- a/pymusiclooper/cli.py
+++ b/pymusiclooper/cli.py
@@ -144,13 +144,12 @@ def play(**kwargs):
 @cli_main.command()
 @click.option('--path', type=click.Path(exists=True), required=True, help='Path to the audio file.')
 @click.option("--tag-names", type=str, required=True, nargs=2, help="Name of the loop metadata tags to read from, e.g. --tag-names LOOP_START LOOP_END  (note: values must be integers and in sample units).")
-@click.option("--offset", is_flag=True, default=False, help="Always parse latter loop metadata tag as a relative length (default auto-detects by name).")
-@click.option("--no-offset", is_flag=True, default=False, help="Always parse latter loop metadata tag as an absolute end position (default auto-detects by name).")
-def play_tagged(path, tag_names, offset, no_offset):
+@click.option("--tag-offset/--no-tag-offset", is_flag=True, default=None, help="Always parse second loop metadata tag as a relative length / or as an absolute length. Default: auto-detected based on tag name.")
+def play_tagged(path, tag_names, tag_offset):
     """Skips loop analysis and reads the loop points directly from the tags present in the file."""
     try:
         looper = MusicLooper(path)
-        loop_start, loop_end = looper.read_tags(tag_names[0], tag_names[1], offset, no_offset)
+        loop_start, loop_end = looper.read_tags(tag_names[0], tag_names[1], tag_offset)
 
         in_samples = "PML_DISPLAY_SAMPLES" in os.environ
 

--- a/pymusiclooper/cli.py
+++ b/pymusiclooper/cli.py
@@ -143,12 +143,14 @@ def play(**kwargs):
 
 @cli_main.command()
 @click.option('--path', type=click.Path(exists=True), required=True, help='Path to the audio file.')
-@click.option("--tag-names", type=str, required=True, nargs=2, help="Name of the loop metadata tags to read from, e.g. --tags-names LOOP_START LOOP_END  (note: values must be integers and in sample units).")
-def play_tagged(path, tag_names):
+@click.option("--tag-names", type=str, required=True, nargs=2, help="Name of the loop metadata tags to read from, e.g. --tag-names LOOP_START LOOP_END  (note: values must be integers and in sample units).")
+@click.option("--offset", is_flag=True, default=False, help="Always parse latter loop metadata tag as a relative length (default auto-detects by name).")
+@click.option("--no-offset", is_flag=True, default=False, help="Always parse latter loop metadata tag as an absolute end position (default auto-detects by name).")
+def play_tagged(path, tag_names, offset, no_offset):
     """Skips loop analysis and reads the loop points directly from the tags present in the file."""
     try:
         looper = MusicLooper(path)
-        loop_start, loop_end = looper.read_tags(tag_names[0], tag_names[1])
+        loop_start, loop_end = looper.read_tags(tag_names[0], tag_names[1], offset, no_offset)
 
         in_samples = "PML_DISPLAY_SAMPLES" in os.environ
 
@@ -216,6 +218,8 @@ def export_points(**kwargs):
 @common_loop_options
 @common_export_options
 @click.option('--tag-names', type=str, required=True, nargs=2, help='Name of the loop metadata tags to use, e.g. --tag-names LOOP_START LOOP_END')
+@click.option("--offset", is_flag=True, default=False, help="Always export latter loop metadata tag as a relative length (default auto-detects by name).")
+@click.option("--no-offset", is_flag=True, default=False, help="Always export latter loop metadata tag as an absolute end position (default auto-detects by name).")
 def tag(**kwargs):
     """Adds metadata tags of loop points to a copy of the input audio file(s)."""
     run_handler(**kwargs)

--- a/pymusiclooper/console.py
+++ b/pymusiclooper/console.py
@@ -46,7 +46,7 @@ _common_option_groups = _option_groups()
 _OPTION_GROUPS = {
     "pymusiclooper play": _common_option_groups,
     "pymusiclooper split-audio": _common_option_groups,
-    "pymusiclooper tag": _option_groups(["--tag-names", "--offset", "--no-offset"]),
+    "pymusiclooper tag": _option_groups(["--tag-names", "--tag-offset"]),
     "pymusiclooper export-points": _option_groups(["--export-to", "--alt-export-top", "--fmt"]),
     "pymusiclooper extend": _option_groups(["--extended-length", "--fade-length", "--disable-fade-out"]),
 }

--- a/pymusiclooper/console.py
+++ b/pymusiclooper/console.py
@@ -46,7 +46,7 @@ _common_option_groups = _option_groups()
 _OPTION_GROUPS = {
     "pymusiclooper play": _common_option_groups,
     "pymusiclooper split-audio": _common_option_groups,
-    "pymusiclooper tag": _option_groups(["--tag-names"]),
+    "pymusiclooper tag": _option_groups(["--tag-names", "--offset", "--no-offset"]),
     "pymusiclooper export-points": _option_groups(["--export-to", "--alt-export-top", "--fmt"]),
     "pymusiclooper extend": _option_groups(["--extended-length", "--fade-length", "--disable-fade-out"]),
 }

--- a/pymusiclooper/core.py
+++ b/pymusiclooper/core.py
@@ -274,12 +274,59 @@ class MusicLooper:
         with open(out_path, "a") as file:
             file.write(f"{loop_start} {loop_end} {self.mlaudio.filename}\n")
 
+
+    def relativize_end_tag(
+        self,
+        loop_start: int,
+        loop_end: int,
+        loop_end_tag: str,
+        always_offset: bool,
+        never_offset: bool,
+    ) -> int:
+        if never_offset:
+            return loop_end
+
+        if always_offset:
+            return loop_end - loop_start
+
+        upper_loop_end_tag = loop_end_tag.upper()
+
+        if "LEN" in upper_loop_end_tag or "OFFSET" in upper_loop_end_tag:
+            return loop_end - loop_start
+
+        return loop_end
+
+
+    def absolutize_end_tag(
+        self,
+        loop_start: int,
+        loop_end: int,
+        loop_end_tag: str,
+        always_offset: bool,
+        never_offset: bool,
+    ) -> int:
+        if never_offset:
+            return loop_end
+
+        if always_offset:
+            return loop_start + loop_end
+
+        upper_loop_end_tag = loop_end_tag.upper()
+
+        if "LEN" in upper_loop_end_tag or "OFFSET" in upper_loop_end_tag:
+            return loop_start + loop_end
+
+        return loop_end
+
+
     def export_tags(
         self,
         loop_start: int,
         loop_end: int,
         loop_start_tag: str,
         loop_end_tag: str,
+        always_offset: bool = False,
+        never_offset: bool = False,
         output_dir: Optional[str] = None
     ):
         """Adds metadata tags of loop points to a copy of the source audio file.
@@ -305,12 +352,15 @@ class MusicLooper:
         )
         shutil.copyfile(self.mlaudio.filepath, exported_file_path)
 
+        # Handle LOOPLENGTH tag
+        loop_end = self.relativize_end_tag(loop_start, loop_end, loop_end_tag, always_offset, never_offset)
+
         with taglib.File(exported_file_path, save_on_exit=True) as audio_file:
             audio_file.tags[loop_start_tag] = [str(loop_start)]
             audio_file.tags[loop_end_tag] = [str(loop_end)]
 
 
-    def read_tags(self, loop_start_tag: str, loop_end_tag: str) -> Tuple[int, int]:
+    def read_tags(self, loop_start_tag: str, loop_end_tag: str, always_offset: bool = False, never_offset: bool = False) -> Tuple[int, int]:
         """Reads the tags provided from the file and returns the read loop points
 
         Args:
@@ -343,5 +393,8 @@ class MusicLooper:
         # Re-order the loop points in case
         real_loop_start = min(loop_start, loop_end)
         real_loop_end = max(loop_start, loop_end)
+
+        # Handle LOOPLENGTH tag
+        real_loop_end = self.absolutize_end_tag(real_loop_start, real_loop_end, loop_end_tag, always_offset, never_offset)
 
         return real_loop_start, real_loop_end

--- a/pymusiclooper/core.py
+++ b/pymusiclooper/core.py
@@ -278,14 +278,10 @@ class MusicLooper:
     def end_tag_is_offset(
         self,
         loop_end_tag: str,
-        always_offset: bool,
-        never_offset: bool,
+        is_offset: Optional[bool],
     ) -> bool:
-        if always_offset:
-            return True
-
-        if never_offset:
-            return False
+        if is_offset is not None:
+            return is_offset
 
         upper_loop_end_tag = loop_end_tag.upper()
 
@@ -297,10 +293,9 @@ class MusicLooper:
         loop_start: int,
         loop_end: int,
         loop_end_tag: str,
-        always_offset: bool,
-        never_offset: bool,
+        is_offset: Optional[bool],
     ) -> int:
-        if self.end_tag_is_offset(loop_end_tag, always_offset, never_offset):
+        if self.end_tag_is_offset(loop_end_tag, is_offset):
             return loop_end - loop_start
 
         return loop_end
@@ -311,10 +306,9 @@ class MusicLooper:
         loop_start: int,
         loop_end: int,
         loop_end_tag: str,
-        always_offset: bool,
-        never_offset: bool,
+        is_offset: Optional[bool],
     ) -> int:
-        if self.end_tag_is_offset(loop_end_tag, always_offset, never_offset):
+        if self.end_tag_is_offset(loop_end_tag, is_offset):
             return loop_start + loop_end
 
         return loop_end
@@ -326,8 +320,7 @@ class MusicLooper:
         loop_end: int,
         loop_start_tag: str,
         loop_end_tag: str,
-        always_offset: bool = False,
-        never_offset: bool = False,
+        is_offset: Optional[bool] = None,
         output_dir: Optional[str] = None
     ):
         """Adds metadata tags of loop points to a copy of the source audio file.
@@ -337,6 +330,7 @@ class MusicLooper:
             loop_end (int): Loop end in samples.
             loop_start_tag (str): Name of the loop_start metadata tag.
             loop_end_tag (str): Name of the loop_end metadata tag.
+            is_offset (bool, optional): Export second tag as relative length / absolute end. Defaults to auto-detecting based on tag name.
             output_dir (str, optional): Path to the output directory. Defaults to the same diretcory as the source audio file.
         """
         # Workaround for taglib import issues on Apple silicon devices
@@ -354,19 +348,20 @@ class MusicLooper:
         shutil.copyfile(self.mlaudio.filepath, exported_file_path)
 
         # Handle LOOPLENGTH tag
-        loop_end = self.relativize_end_tag(loop_start, loop_end, loop_end_tag, always_offset, never_offset)
+        loop_end = self.relativize_end_tag(loop_start, loop_end, loop_end_tag, is_offset)
 
         with taglib.File(exported_file_path, save_on_exit=True) as audio_file:
             audio_file.tags[loop_start_tag] = [str(loop_start)]
             audio_file.tags[loop_end_tag] = [str(loop_end)]
 
 
-    def read_tags(self, loop_start_tag: str, loop_end_tag: str, always_offset: bool = False, never_offset: bool = False) -> Tuple[int, int]:
+    def read_tags(self, loop_start_tag: str, loop_end_tag: str, is_offset: Optional[bool] = None) -> Tuple[int, int]:
         """Reads the tags provided from the file and returns the read loop points
 
         Args:
             loop_start_tag (str): The name of the metadata tag containing the loop_start value
             loop_end_tag (str): The name of the metadata tag containing the loop_end value
+            is_offset (bool, optional): Parse second tag as relative length / absolute end. Defaults to auto-detecting based on tag name.
 
         Returns:
             Tuple[int, int]: A tuple containing (loop_start, loop_end)
@@ -396,6 +391,6 @@ class MusicLooper:
         real_loop_end = max(loop_start, loop_end)
 
         # Handle LOOPLENGTH tag
-        real_loop_end = self.absolutize_end_tag(real_loop_start, real_loop_end, loop_end_tag, always_offset, never_offset)
+        real_loop_end = self.absolutize_end_tag(real_loop_start, real_loop_end, loop_end_tag, is_offset)
 
         return real_loop_start, real_loop_end

--- a/pymusiclooper/core.py
+++ b/pymusiclooper/core.py
@@ -288,32 +288,6 @@ class MusicLooper:
         return "LEN" in upper_loop_end_tag or "OFFSET" in upper_loop_end_tag
 
 
-    def relativize_end_tag(
-        self,
-        loop_start: int,
-        loop_end: int,
-        loop_end_tag: str,
-        is_offset: Optional[bool],
-    ) -> int:
-        if self.end_tag_is_offset(loop_end_tag, is_offset):
-            return loop_end - loop_start
-
-        return loop_end
-
-
-    def absolutize_end_tag(
-        self,
-        loop_start: int,
-        loop_end: int,
-        loop_end_tag: str,
-        is_offset: Optional[bool],
-    ) -> int:
-        if self.end_tag_is_offset(loop_end_tag, is_offset):
-            return loop_start + loop_end
-
-        return loop_end
-
-
     def export_tags(
         self,
         loop_start: int,
@@ -348,7 +322,8 @@ class MusicLooper:
         shutil.copyfile(self.mlaudio.filepath, exported_file_path)
 
         # Handle LOOPLENGTH tag
-        loop_end = self.relativize_end_tag(loop_start, loop_end, loop_end_tag, is_offset)
+        if self.end_tag_is_offset(loop_end_tag, is_offset):
+            loop_end = loop_end - loop_start
 
         with taglib.File(exported_file_path, save_on_exit=True) as audio_file:
             audio_file.tags[loop_start_tag] = [str(loop_start)]
@@ -391,6 +366,7 @@ class MusicLooper:
         real_loop_end = max(loop_start, loop_end)
 
         # Handle LOOPLENGTH tag
-        real_loop_end = self.absolutize_end_tag(real_loop_start, real_loop_end, loop_end_tag, is_offset)
+        if self.end_tag_is_offset(loop_end_tag, is_offset):
+            real_loop_end = real_loop_start + real_loop_end
 
         return real_loop_start, real_loop_end

--- a/pymusiclooper/core.py
+++ b/pymusiclooper/core.py
@@ -275,6 +275,23 @@ class MusicLooper:
             file.write(f"{loop_start} {loop_end} {self.mlaudio.filename}\n")
 
 
+    def end_tag_is_offset(
+        self,
+        loop_end_tag: str,
+        always_offset: bool,
+        never_offset: bool,
+    ) -> bool:
+        if always_offset:
+            return True
+
+        if never_offset:
+            return False
+
+        upper_loop_end_tag = loop_end_tag.upper()
+
+        return "LEN" in upper_loop_end_tag or "OFFSET" in upper_loop_end_tag
+
+
     def relativize_end_tag(
         self,
         loop_start: int,
@@ -283,15 +300,7 @@ class MusicLooper:
         always_offset: bool,
         never_offset: bool,
     ) -> int:
-        if never_offset:
-            return loop_end
-
-        if always_offset:
-            return loop_end - loop_start
-
-        upper_loop_end_tag = loop_end_tag.upper()
-
-        if "LEN" in upper_loop_end_tag or "OFFSET" in upper_loop_end_tag:
+        if self.end_tag_is_offset(loop_end_tag, always_offset, never_offset):
             return loop_end - loop_start
 
         return loop_end
@@ -305,15 +314,7 @@ class MusicLooper:
         always_offset: bool,
         never_offset: bool,
     ) -> int:
-        if never_offset:
-            return loop_end
-
-        if always_offset:
-            return loop_start + loop_end
-
-        upper_loop_end_tag = loop_end_tag.upper()
-
-        if "LEN" in upper_loop_end_tag or "OFFSET" in upper_loop_end_tag:
+        if self.end_tag_is_offset(loop_end_tag, always_offset, never_offset):
             return loop_start + loop_end
 
         return loop_end

--- a/pymusiclooper/core.py
+++ b/pymusiclooper/core.py
@@ -275,7 +275,7 @@ class MusicLooper:
             file.write(f"{loop_start} {loop_end} {self.mlaudio.filename}\n")
 
 
-    def end_tag_is_offset(
+    def _end_tag_is_offset(
         self,
         loop_end_tag: str,
         is_offset: Optional[bool],
@@ -322,7 +322,7 @@ class MusicLooper:
         shutil.copyfile(self.mlaudio.filepath, exported_file_path)
 
         # Handle LOOPLENGTH tag
-        if self.end_tag_is_offset(loop_end_tag, is_offset):
+        if self._end_tag_is_offset(loop_end_tag, is_offset):
             loop_end = loop_end - loop_start
 
         with taglib.File(exported_file_path, save_on_exit=True) as audio_file:
@@ -366,7 +366,7 @@ class MusicLooper:
         real_loop_end = max(loop_start, loop_end)
 
         # Handle LOOPLENGTH tag
-        if self.end_tag_is_offset(loop_end_tag, is_offset):
+        if self._end_tag_is_offset(loop_end_tag, is_offset):
             real_loop_end = real_loop_start + real_loop_end
 
         return real_loop_start, real_loop_end

--- a/pymusiclooper/core.py
+++ b/pymusiclooper/core.py
@@ -296,7 +296,7 @@ class MusicLooper:
         loop_end_tag: str,
         is_offset: Optional[bool] = None,
         output_dir: Optional[str] = None
-    ):
+    ) -> Tuple[str]:
         """Adds metadata tags of loop points to a copy of the source audio file.
 
         Args:
@@ -328,6 +328,8 @@ class MusicLooper:
         with taglib.File(exported_file_path, save_on_exit=True) as audio_file:
             audio_file.tags[loop_start_tag] = [str(loop_start)]
             audio_file.tags[loop_end_tag] = [str(loop_end)]
+
+        return str(loop_start), str(loop_end)
 
 
     def read_tags(self, loop_start_tag: str, loop_end_tag: str, is_offset: Optional[bool] = None) -> Tuple[int, int]:

--- a/pymusiclooper/handler.py
+++ b/pymusiclooper/handler.py
@@ -343,7 +343,7 @@ class LoopExportHandler(LoopHandler):
 
     def tag_runner(self, loop_start: int, loop_end: int):        
         loop_start_tag, loop_end_tag = self.tag_names
-        self.musiclooper.export_tags(
+        loop_start, loop_end = self.musiclooper.export_tags(
             loop_start,
             loop_end,
             loop_start_tag,

--- a/pymusiclooper/handler.py
+++ b/pymusiclooper/handler.py
@@ -188,6 +188,8 @@ class LoopExportHandler(LoopHandler):
         fmt: Literal["SAMPLES", "SECONDS", "TIME"] = "SAMPLES",
         alt_export_top: int = 0,
         tag_names: Optional[Tuple[str, str]] = None,
+        offset: bool = False,
+        no_offset: bool = False,
         batch_mode: bool = False,
         extended_length: float = 0,
         fade_length: float = 0,
@@ -211,6 +213,8 @@ class LoopExportHandler(LoopHandler):
         self.fmt = fmt.lower()
         self.alt_export_top = alt_export_top
         self.tag_names = tag_names
+        self.always_offset = offset
+        self.never_offset = no_offset
         self.batch_mode = batch_mode
         self.extended_length = extended_length
         self.disable_fade_out = disable_fade_out
@@ -346,6 +350,8 @@ class LoopExportHandler(LoopHandler):
             loop_end,
             loop_start_tag,
             loop_end_tag,
+            always_offset=self.always_offset,
+            never_offset=self.never_offset,
             output_dir=self.output_directory,
         )
         message = f"Exported {loop_start_tag}: {loop_start} and {loop_end_tag}: {loop_end} of \"{self.musiclooper.filename}\" to a copy in \"{self.output_directory}\""

--- a/pymusiclooper/handler.py
+++ b/pymusiclooper/handler.py
@@ -188,7 +188,7 @@ class LoopExportHandler(LoopHandler):
         fmt: Literal["SAMPLES", "SECONDS", "TIME"] = "SAMPLES",
         alt_export_top: int = 0,
         tag_names: Optional[Tuple[str, str]] = None,
-        is_offset: Optional[bool] = None,
+        tag_offset: Optional[bool] = None,
         batch_mode: bool = False,
         extended_length: float = 0,
         fade_length: float = 0,
@@ -212,7 +212,7 @@ class LoopExportHandler(LoopHandler):
         self.fmt = fmt.lower()
         self.alt_export_top = alt_export_top
         self.tag_names = tag_names
-        self.is_offset = is_offset
+        self.tag_offset = tag_offset
         self.batch_mode = batch_mode
         self.extended_length = extended_length
         self.disable_fade_out = disable_fade_out
@@ -348,7 +348,7 @@ class LoopExportHandler(LoopHandler):
             loop_end,
             loop_start_tag,
             loop_end_tag,
-            is_offset=self.is_offset,
+            is_offset=self.tag_offset,
             output_dir=self.output_directory,
         )
         message = f"Exported {loop_start_tag}: {loop_start} and {loop_end_tag}: {loop_end} of \"{self.musiclooper.filename}\" to a copy in \"{self.output_directory}\""

--- a/pymusiclooper/handler.py
+++ b/pymusiclooper/handler.py
@@ -188,8 +188,7 @@ class LoopExportHandler(LoopHandler):
         fmt: Literal["SAMPLES", "SECONDS", "TIME"] = "SAMPLES",
         alt_export_top: int = 0,
         tag_names: Optional[Tuple[str, str]] = None,
-        offset: bool = False,
-        no_offset: bool = False,
+        is_offset: Optional[bool] = None,
         batch_mode: bool = False,
         extended_length: float = 0,
         fade_length: float = 0,
@@ -213,8 +212,7 @@ class LoopExportHandler(LoopHandler):
         self.fmt = fmt.lower()
         self.alt_export_top = alt_export_top
         self.tag_names = tag_names
-        self.always_offset = offset
-        self.never_offset = no_offset
+        self.is_offset = is_offset
         self.batch_mode = batch_mode
         self.extended_length = extended_length
         self.disable_fade_out = disable_fade_out
@@ -350,8 +348,7 @@ class LoopExportHandler(LoopHandler):
             loop_end,
             loop_start_tag,
             loop_end_tag,
-            always_offset=self.always_offset,
-            never_offset=self.never_offset,
+            is_offset=self.is_offset,
             output_dir=self.output_directory,
         )
         message = f"Exported {loop_start_tag}: {loop_start} and {loop_end_tag}: {loop_end} of \"{self.musiclooper.filename}\" to a copy in \"{self.output_directory}\""


### PR DESCRIPTION
Fixes https://github.com/arkrow/PyMusicLooper/issues/45

Also fixes a documentation typo (`--tags-names` should be `--tag-names`)

## Summary by Sourcery

Implement support for the LOOPLENGTH tag in the PyMusicLooper project, allowing users to export and read this tag in audio files. Enhance the CLI with new options to specify how loop metadata tags are interpreted, and fix a typo in the documentation.

New Features:
- Add support for exporting and reading the LOOPLENGTH tag in audio files.

Bug Fixes:
- Correct a documentation typo by changing --tags-names to --tag-names.

Enhancements:
- Introduce options to handle loop metadata tags as either relative lengths or absolute end positions with --offset and --no-offset flags.