### PR TITLE
Improve experience when system does not have PortAudio installed yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ The following software must be installed for `pymusiclooper` to function correct
 Supported audio formats *without* ffmpeg include: WAV, FLAC, Ogg/Vorbis, Ogg/Opus, MP3.
 A full list can be found at [libsndfile's supported formats page](https://libsndfile.github.io/libsndfile/formats.html)
 
+Additionally, to use the `play` command on Linux systems, you may need to
+install the PortAudio library. On Ubuntu, run `sudo apt install libportaudio2`.
+
 ## Installation
 
 ### Option 1: Installing using pipx [Recommended]


### PR DESCRIPTION
When I tried to use `pymusiclooper` for the first time, I ran into a confusing error message on playback:

```
ERROR    module 'sounddevice' has no attribute 'OutputStream'
```

To debug, I ran `~/.local/pipx/venvs/pymusiclooper/bin/python`, and tried importing the `sounddevice` library, and got this clearer error message:

```
>>> import sounddevice
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/matchu/.local/pipx/venvs/pymusiclooper/lib/python3.10/site-packages/sounddevice.py", line 71, in <module>
    raise OSError('PortAudio library not found')
OSError: PortAudio library not found
```

Researching a bit, it looks like the `lazy-loader` library imports modules in a slightly complex way, which happens to not raise import side-effects like this one.

So, in this PR, I've made two changes:

1. Add instructions to the README to help Linux users understand that they may need to install PortAudio, and how to do it.
2. Replace the `lazy-loader` call with our own simple hand-written lazy-loader function for `sounddevice`, which will raise the more helpful error message if the user is missing PortAudio.

Thank you for this tool! I hope this is helpful.

## Summary by Sourcery

Improve user experience by providing clearer error messages when PortAudio is not installed and update documentation to guide Linux users on installing PortAudio.

Enhancements:
- Replace the 'lazy-loader' call with a custom lazy-loader function for 'sounddevice' to provide clearer error messages when dependencies like PortAudio are missing.

Documentation:
- Add instructions to the README for Linux users on how to install the PortAudio library if needed.