### PR TITLE
Prevent division by zero in _calculate_subseq_beat_similarity

### DIFF
--- a/pymusiclooper/analysis.py
+++ b/pymusiclooper/analysis.py
@@ -519,7 +519,7 @@ def _calculate_subseq_beat_similarity(
     )
     b1_norm = np.linalg.norm(chroma[..., b1_start:b1_end], axis=0)
     b2_norm = np.linalg.norm(chroma[..., b2_start:b2_end], axis=0)
-    cosine_sim = dot_prod / (b1_norm * b2_norm)
+    cosine_sim = dot_prod / (np.maximum(b1_norm * b2_norm, 1e-10))
 
     if max_offset < test_length:
         return np.average(


### PR DESCRIPTION
I have some files that are somehow causing all of the scores to end up as 'nan%', preventing sorting and making it quite difficult to find the correct loop.

Adding a minimum value here allows the score values to not end up as 'nan%'